### PR TITLE
Fix `pgm_read_ptr()`'s return type

### DIFF
--- a/cores/arduino/api/deprecated-avr-comp/avr/pgmspace.h
+++ b/cores/arduino/api/deprecated-avr-comp/avr/pgmspace.h
@@ -103,7 +103,7 @@ typedef const void *uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(void *const *)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
Calling `pgm_read_ptr()` causes the following error:

    'const void*' is not a pointer-to-object type"

Related to arduino/ArduinoCore-API#118
Fixes bblanchon/ArduinoJson#1947